### PR TITLE
Refactor calendar tool to use operation models

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,6 +1,7 @@
 from .task import Task, TodoistTask, TaskPriority, TaskStatus
 from .event import CalendarEvent, EventRecurrence, EventReminder
 from .context import PlanningContext, EntityContext, UserPreferences
+from .calendar_tool import CalendarOperation, CalendarResponse
 
 __all__ = [
     'Task',
@@ -13,4 +14,6 @@ __all__ = [
     'PlanningContext',
     'EntityContext',
     'UserPreferences',
+    'CalendarOperation',
+    'CalendarResponse',
 ]

--- a/src/models/calendar_tool.py
+++ b/src/models/calendar_tool.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Pydantic models for calendar tool operations and responses."""
+
+from datetime import datetime
+from typing import Optional, Dict, Any
+from pydantic import BaseModel
+
+
+class CalendarOperation(BaseModel):
+    """Input model for calendar operations."""
+    operation: str  # "list", "create", "update", "delete", "find_free_slots"
+    calendar_name: Optional[str] = "Calendar"
+    event_data: Optional[Dict[str, Any]] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    event_id: Optional[str] = None
+
+
+class CalendarResponse(BaseModel):
+    """Standard response wrapper for calendar operations."""
+    result: str

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -3,12 +3,13 @@
 This module avoids importing heavy/strict-schema tools at import time to ensure
 the application can start even if optional integrations aren't configured.
 """
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Callable
 import json
 from agents import function_tool
+from models.calendar_tool import CalendarOperation, CalendarResponse
 
 
-def create_calendar_tool():
+def create_calendar_tool() -> Callable[[CalendarOperation], CalendarResponse]:
     """Return the calendar tool (lazy-imports the module)."""
     from .calendar_tool import manage_calendar
     return manage_calendar

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -24,7 +24,7 @@ class TestCalendarTool:
     @pytest.mark.asyncio
     async def test_calendar_tool_structure(self):
         """Test that calendar tool returns proper JSON structure"""
-        from models.calendar_tool import CalendarOperation
+        from models.calendar_tool import CalendarOperation, CalendarResponse
         
         # Test list operation (should handle gracefully even without calendar access)
         operation = CalendarOperation(
@@ -34,17 +34,18 @@ class TestCalendarTool:
         )
         
         result = await manage_calendar(operation)
-        
-        # Should return JSON string
-        assert isinstance(result, str)
-        
+
+        # Should return CalendarResponse with JSON string
+        assert isinstance(result, CalendarResponse)
+        assert isinstance(result.result, str)
+
         # Should be parseable as JSON
         try:
-            parsed = json.loads(result)
+            parsed = json.loads(result.result)
             assert isinstance(parsed, (dict, list))
         except json.JSONDecodeError:
             # If not JSON, should at least be a string response
-            assert len(result) > 0
+            assert len(result.result) > 0
 
 
 class TestNLPTool:


### PR DESCRIPTION
## Summary
- add CalendarOperation and CalendarResponse models
- refactor manage_calendar to accept a CalendarOperation and return CalendarResponse
- adjust calendar tool factory and tests for new API

## Testing
- `pytest -q` *(fails: No module named 'context_manager')*

------
https://chatgpt.com/codex/tasks/task_e_68a48eee70048329838e729e7a2e176d