### PR TITLE
Ensure logs directory exists before configuring logging

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -17,14 +17,19 @@ from agent_modules import create_orchestrator_agent
 
 def setup_logging():
     """Configure logging for the application"""
+    # Ensure the logs directory exists before configuring logging
+    log_dir = Path("logs")
+    log_dir.mkdir(parents=True, exist_ok=True)
+
     log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     logging.basicConfig(
         level=getattr(logging, config.log_level),
         format=log_format,
         handlers=[
-            logging.FileHandler("logs/planner.log"),
+            logging.FileHandler(log_dir / "planner.log"),
             logging.StreamHandler()
-        ]
+        ],
+        force=True
     )
     
     # Set specific loggers to warning to reduce noise


### PR DESCRIPTION
## Summary
- Create `logs/` directory prior to configuring logging
- Configure logging with path objects and force overriding existing handlers

## Testing
- `PYTHONPATH=. pytest tests`
- `printf "/exit\n" | OPENAI_API_KEY=test python src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5021952c48329acb9d2fa2f6ac169