### PR TITLE
Define strict calendar tool schema

### DIFF
--- a/src/models/calendar_tool.py
+++ b/src/models/calendar_tool.py
@@ -1,14 +1,26 @@
 from __future__ import annotations
 from typing import Optional, Any, List
 from datetime import datetime
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+
+class CalendarEventData(BaseModel):
+    """Minimal event data required for calendar operations"""
+    summary: str = Field(..., description="Event title/summary")
+    start_date: datetime = Field(..., description="Event start in ISO format")
+    end_date: datetime = Field(..., description="Event end in ISO format")
+    description: Optional[str] = Field(None, description="Event description")
+    location: Optional[str] = Field(None, description="Event location")
+    all_day: bool = Field(False, description="Is this an all-day event")
+
+    model_config = {"extra": "forbid"}
 
 
 class CalendarOperation(BaseModel):
     """Input for calendar operations"""
     operation: str
     calendar_name: Optional[str] = "Calendar"
-    event_data: Optional[Any] = None
+    event_data: Optional[CalendarEventData] = None
     start_date: Optional[datetime] = None
     end_date: Optional[datetime] = None
     event_id: Optional[str] = None

--- a/src/tools/calendar_tool.py
+++ b/src/tools/calendar_tool.py
@@ -28,6 +28,8 @@ async def _manage_calendar_impl(operation_input: CalendarOperation) -> CalendarR
     end_date = operation_input.end_date
     event_id = operation_input.event_id
     event_data = operation_input.event_data
+    if isinstance(event_data, BaseModel):
+        event_data = event_data.model_dump(mode="json")
 
     try:
         if operation == "list":

--- a/test_main_app.py
+++ b/test_main_app.py
@@ -7,6 +7,7 @@ import sys
 import os
 from pathlib import Path
 from unittest.mock import Mock, patch, AsyncMock
+import pytest
 
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "src"))
@@ -15,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).parent / "src"))
 os.environ["OPENAI_API_KEY"] = "test-key"
 
 
+@pytest.mark.asyncio
 async def test_main_app():
     """Test the main application startup and basic functionality"""
     from config import config


### PR DESCRIPTION
## Summary
- add `CalendarEventData` model and use it in `CalendarOperation` to satisfy OpenAI schema requirements
- serialize Pydantic `event_data` before invoking calendar operations
- mark main app test as asyncio and import pytest

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4fff52874832982f9eb22b8f3addc